### PR TITLE
Update build workflows

### DIFF
--- a/.github/workflows/docfx-build-publish.yml
+++ b/.github/workflows/docfx-build-publish.yml
@@ -8,21 +8,18 @@ on:
 
 jobs:
   generate-docs:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v3
         
       - name: Create empty TeeChart license file
         run: copy /Y nul > "source\My Project\TeeChart.licenses"
         shell: cmd
         
       - name: Build Wave
-        run: msbuild source\Wave.vbproj -restore -property:Platform=x64 -property:Configuration=Release
+        run: dotnet build source\Wave.vbproj --arch x64 --configuration Release
         
       - name: Install DocFX
         run: dotnet tool install -g docfx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
       - name: Parse version from latest tag
@@ -16,9 +16,6 @@ jobs:
         
       - name: Checkout
         uses: actions/checkout@v6
-        
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v3
         
       - name: Create TeeChart license file from secret
         uses: lukasa1993/secret-file-action@v1.0.4
@@ -31,10 +28,10 @@ jobs:
         run: copy ${{ steps.teechart-license.outputs.file }} "source\My Project\TeeChart.licenses"
         
       - name: Build Wave
-        run: msbuild source\Wave.vbproj -restore -property:Platform=x64 -property:Configuration=Release
+        run: dotnet build source\Wave.vbproj --arch x64 --configuration Release
         
       - name: Create zip archive
-        run: Compress-Archive -Path source\bin\x64\Release\* -DestinationPath BlueM.Wave_${{ steps.version.outputs.full }}_x64.zip
+        run: Compress-Archive -Path source\bin\Release\net10.0-windows\win-x64\* -DestinationPath BlueM.Wave_${{ steps.version.outputs.full }}_x64.zip
         
       - name: Setup VS Dev Environment
         uses: seanmiddleditch/gha-setup-vsdevenv@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet build BlueM.Wave\tests\Wave.Tests.vbproj --arch x64 --configuration Release
         
       - name: Run Tests
-        run: dotnet test BlueM.Wave\tests\bin\x64\Release\net10.0-windows\Wave.Tests.dll --settings BlueM.Wave\tests\tests.runsettings
+        run: dotnet test BlueM.Wave\tests\bin\Release\net10.0-windows\win-x64\Wave.Tests.dll --settings BlueM.Wave\tests\tests.runsettings
           
       - name: Upload test results
         if: always()

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
       - name: Checkout BlueM.Wave
@@ -23,19 +23,15 @@ jobs:
           ref: net
           path: BlueM.Datasets
           
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v3
-        
       - name: Create empty TeeChart license file
         run: copy /Y nul > "BlueM.Wave\source\My Project\TeeChart.licenses"
         shell: cmd
         
       - name: Build Wave.Tests
-        run: msbuild BlueM.Wave\tests\Wave.Tests.vbproj -restore -property:Platform=x64 -property:Configuration=Debug
+        run: dotnet build BlueM.Wave\tests\Wave.Tests.vbproj --arch x64 --configuration Release
         
       - name: Run Tests
-        run: |
-          dotnet test BlueM.Wave\tests\bin\x64\Debug\net10.0-windows\Wave.Tests.dll --settings BlueM.Wave\tests\tests.runsettings
+        run: dotnet test BlueM.Wave\tests\bin\x64\Release\net10.0-windows\Wave.Tests.dll --settings BlueM.Wave\tests\tests.runsettings
           
       - name: Upload test results
         if: always()

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -30,7 +30,7 @@ ts.Cut(New DateTime(2000, 1, 2), New DateTime(2000, 1, 3))
 ```
 
 ### TimeSeriesFile
-You can use the [`BlueM.Wave.TimeSeriesFile`](xref:BlueM.Wave.TimeSeriesFile) class' factory method [`getInstance()`](xref:BlueM.Wave.TimeSeriesFile#BlueM_Wave_TimeSeriesFile_getInstance_System_String_BlueM_Wave_TimeSeriesFile_FileTypes_) to read time series from any of the supported file formats:
+You can use the [`BlueM.Wave.TimeSeriesFile`](xref:BlueM.Wave.TimeSeriesFile) class' factory method [`GetInstance()`](xref:BlueM.Wave.TimeSeriesFile#BlueM_Wave_TimeSeriesFile_GetInstance_System_String_BlueM_Wave_TimeSeriesFile_FileTypes_) to read time series from any of the supported file formats:
 ```vb
 Dim filepath as String = "path\to\file"
 Dim tsfile as BlueM.Wave.TimeSeriesFile = BlueM.Wave.TimeSeriesFile.getInstance(filepath)
@@ -41,11 +41,11 @@ For Each sInfo As BlueM.Wave.TimeSeriesInfo In tsfile.TimeSeriesInfos
 Next
 
 'select some or all series for import
-tsFile.selectSeries("name or index")
-tsfile.selectAllSeries()
+tsFile.SelectSeries("name or index")
+tsfile.SelectAllSeries()
 
 'read the selected time series from the file
-tsfile.readFile()
+tsfile.ReadFile()
 
 'loop over all series read from the file and print some information about them
 For Each ts As BlueM.Wave.TimeSeries In tsfile.TimeSeries.Values
@@ -56,7 +56,7 @@ For Each ts As BlueM.Wave.TimeSeries In tsfile.TimeSeries.Values
 Next
 
 'get one particular time series (selects the series and reads it from the file if necessary)
-Dim ts As BlueM.Wave.TimeSeries = tsfile.getTimeSeries("name or index")
+Dim ts As BlueM.Wave.TimeSeries = tsfile.GetTimeSeries("name or index")
 ```
 
 The namespace [`BlueM.Wave.Fileformats`](xref:BlueM.Wave.Fileformats) contains special classes for reading from specific file formats, which all inherit from [`TimeSeriesFile`](xref:BlueM.Wave.TimeSeriesFile).

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -6,7 +6,7 @@
           "files": [
             "Wave.dll"
           ],
-          "src": "../source/bin/x64/Release/net10.0-windows"
+          "src": "../source/bin/Release/net10.0-windows/win-x64"
         }
       ],
       "dest": "api",


### PR DESCRIPTION
Switch from `msbuild` to `dotnet build` and use runners with VS2026

https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners